### PR TITLE
syntax fixes in multiple stories

### DIFF
--- a/content/stories/home24.md
+++ b/content/stories/home24.md
@@ -17,7 +17,7 @@ stats:
     title: Annual Revenue
 recommended:
   1:
-    story: blu-dot
+    story: bludot
   2:
     story: sony
   3:

--- a/content/stories/marc-opolo.md
+++ b/content/stories/marc-opolo.md
@@ -19,7 +19,7 @@ recommended:
   1:
     story: sony
   2:
-    story: trunk-club
+    story: trunkclub-desktop
   3:
     story: ringier
 
@@ -62,7 +62,7 @@ Then, set up the variations in the experiment and describe them before dropping 
   {
     images: [
       'https://d1qmdf3vop2l07.cloudfront.net/optimizely-marketer-assets.cloudvent.net/raw/customer-stories/customer-stories-pages/marc-opolo/marc-opolo-1.png',
-      'https://d1qmdf3vop2l07.cloudfront.net/optimizely-marketer-assets.cloudvent.net/raw/customer-stories/customer-stories-pages/marc-opolo/marc-opolo-2.png'
+      'https://d1qmdf3vop2l07.cloudfront.net/optimizely-marketer-assets.cloudvent.net/raw/customer-stories/customer-stories-pages/marc-opolo/marc-opolo-2.png',
       'https://d1qmdf3vop2l07.cloudfront.net/optimizely-marketer-assets.cloudvent.net/raw/customer-stories/customer-stories-pages/marc-opolo/marc-opolo-3.png'
     ],
   }

--- a/content/stories/verivox.md
+++ b/content/stories/verivox.md
@@ -1,6 +1,6 @@
 ---
 shortname: verivox
-title: "Testing at Verivox - Small Team, Big Impact"
+title: "Testing at Verivox: Small Team, Big Impact"
 category: Energy / Telecommunications
 hero:
   title: "Testing at Verivox: Small Team, Big Impact"

--- a/content/stories/verivox.md
+++ b/content/stories/verivox.md
@@ -1,9 +1,9 @@
 ---
 shortname: verivox
-title: Testing at Verivox: Small Team, Big Impact
+title: "Testing at Verivox - Small Team, Big Impact"
 category: Energy / Telecommunications
 hero:
-  title: Testing at Verivox: Small Team, Big Impact
+  title: "Testing at Verivox: Small Team, Big Impact"
   subtitle: Nimble, efficient optimization strategy helped increase cross-sells by 70%
 recommended:
   1:
@@ -12,7 +12,6 @@ recommended:
     story: citrix
   3:
     story: ringier
-
 ---
 {% include "case-study-box.html"
   {
@@ -53,7 +52,7 @@ Frank works with product managers across divisions to build the company’s test
 {% include "blockquote.html"
   {
     size: 'full',
-    quote: 'It's surprising just how much can be achieved using Optimizely’s visual editor.',
+    quote: 'It’s surprising just how much can be achieved using Optimizely’s visual editor.',
     attribution: 'Frank Herberg, Conversion Architect, Verivox'
   }
 %}


### PR DESCRIPTION
@robinjohnson 
### Errors fixed:
1. correcting title names in recommended stories
2. adding comma in `includes` statement
3. using an apostrophe instead of a single quote
4. When using a colon, put the string in quotes

@robinjohnson I also noticed images aren't loading correctly in verivox.html. Could you take a look at that?
